### PR TITLE
Update to dotnet 8, remove Newtonsoft.Json dependency.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0'
+        dotnet-version: '8.0'
 
     - name: Restore dependencies
       run: dotnet restore ./Telegraph.Sharp.sln
@@ -45,9 +45,9 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '8.0.x'
 
     - name: Restore dependencies
       run: dotnet restore ./src/Telegraph.Sharp/Telegraph.Sharp.csproj

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![package](https://img.shields.io/nuget/vpre/Telegraph.Sharp.svg)](https://www.nuget.org/packages/Telegraph.Sharp)
 
-Simple to use API client for [Telegra.ph](https://telegra.ph) on .NET 6.
+Simple to use API client for [Telegra.ph](https://telegra.ph) on .NET 8.
+
+For other dotnet version use package [version 1](https://www.nuget.org/packages/Telegraph.Sharp/1.0.0) instead.
 
 ## Quickstart
 
@@ -13,10 +15,10 @@ using Telegraph.Sharp;
 using Telegraph.Sharp.Types;
 
 // Create API client
-var telegraphClient = new TelegraphClient();
+ITelegraphClient telegraphClient = new TelegraphClient();
 
 // Create Telegraph account
-var account = await telegraphClient.CreateAccountAsync("Short Name", "Author name", "Author URL");
+Account account = await telegraphClient.CreateAccountAsync("Short Name", "Author name", "Author URL");
 
 // Provide access token
 telegraphClient.AccessToken = account.AccessToken;
@@ -28,5 +30,5 @@ var pageContent = new List<Node>
     Node.P("Test page")
 };
 
-var page = await telegraphClient.CreatePageAsync("Title", pageContent);
+Page page = await telegraphClient.CreatePageAsync("Title", pageContent);
 ```

--- a/src/Telegraph.Sharp/Converters/NodeConverter.cs
+++ b/src/Telegraph.Sharp/Converters/NodeConverter.cs
@@ -1,83 +1,66 @@
 ﻿using System;
-using System.Linq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Telegraph.Sharp.Types;
 
 namespace Telegraph.Sharp.Converters;
 
-internal class NodeConverter : JsonConverter
+internal class NodeConverter : JsonConverter<Node>
 {
     public override bool CanConvert(Type objectType) => objectType == typeof(Node);
 
-    public override object ReadJson(JsonReader reader, Type objectType, object? existingValue,
-        JsonSerializer serializer)
+    public override Node Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
+        using var document = JsonDocument.ParseValue(ref reader);
+        var rootElement = document.RootElement;
+        if(rootElement.ValueKind == JsonValueKind.String)
+        {
+            return new Node { Value = rootElement.GetString()! };
+        }
         var node = new Node();
-        var token = JToken.Load(reader);
 
-        if (token.Type != JTokenType.Object)
+        if (rootElement.TryGetProperty("tag", out var tagElement))
         {
-            node.Value = token.ToString();
-            return node;
+            node.TagValue = tagElement.GetString()!;
+        }
+        
+        if (rootElement.TryGetProperty("attrs", out var attrsElement))
+        {
+            node.Attributes = attrsElement.Deserialize<TagAttributes>(options);
         }
 
-        var type = typeof(Node);
-        foreach (var property in type.GetProperties())
+        if (rootElement.TryGetProperty("children", out var childrenElement))
         {
-            var name = property.Name;
-            var attributes = property.GetCustomAttributes(false);
-
-            if (attributes.Any(att => att is JsonIgnoreAttribute)) continue;
-
-            var jsonPropertyAttribute = attributes.FirstOrDefault(att => att is JsonPropertyAttribute);
-            if (jsonPropertyAttribute is JsonPropertyAttribute attr) name = attr.PropertyName;
-
-            property.SetValue(node, token[name!]?.ToObject(property.PropertyType));
+            node.Children = childrenElement.Deserialize<List<Node>>(options);
         }
 
-        if (node.Attributes is { Href: null, Src: null }) node.Attributes = null;
         return node;
     }
 
-    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+
+    public override void Write(Utf8JsonWriter writer, Node value, JsonSerializerOptions options)
     {
-        var node = value as Node;
-
-        if (node?.Value != null)
+        if(!string.IsNullOrEmpty(value.Value))
         {
-            writer.WriteValue(node.Value);
+            writer.WriteStringValue(value.Value);
+            return;
         }
-        else
+        writer.WriteStartObject();
+        writer.WriteString("tag", value.TagValue);
+        if (value.Attributes != null)
         {
-            writer.WriteStartObject();
-
-            var type = value!.GetType();
-
-            foreach (var item in type.GetProperties().Where(v => v.Name != nameof(Node.Children)))
-            {
-                var name = item.Name;
-                var attrs = item.GetCustomAttributes(false);
-
-
-                if (attrs.Any(v => v is JsonIgnoreAttribute)) continue;
-                foreach (JsonPropertyAttribute attr in attrs.Where(v => v is JsonPropertyAttribute))
-                    name = attr.PropertyName;
-                writer.WritePropertyName(name!);
-                serializer.Serialize(writer, item.GetValue(value));
-            }
-
-            var childrenProp = type.GetProperties().FirstOrDefault(v => v.Name == nameof(Node.Children));
-            var clildrenName = childrenProp!.Name;
-
-            var childrenPropAtrs = childrenProp.GetCustomAttributes(false);
-            foreach (JsonPropertyAttribute attr in childrenPropAtrs.Where(v => v is JsonPropertyAttribute))
-                clildrenName = attr.PropertyName;
-
-            writer.WritePropertyName(clildrenName!);
-            serializer.Serialize(writer, childrenProp.GetValue(value));
-
-            writer.WriteEndObject();
+            writer.WritePropertyName("attrs");
+            JsonSerializer.Serialize(writer, value.Attributes, options);
         }
+        if (value.Children is { Count: > 0 })
+        {
+            writer.WritePropertyName("children");
+            JsonSerializer.Serialize(writer, value.Children, options);
+        }
+
+        writer.WriteEndObject();
+
     }
+
 }

--- a/src/Telegraph.Sharp/Extensions/JsonSerializerExtensions.cs
+++ b/src/Telegraph.Sharp/Extensions/JsonSerializerExtensions.cs
@@ -1,0 +1,11 @@
+using System.Text.Json;
+
+namespace Telegraph.Sharp.Extensions;
+
+internal static class JsonSerializerExtensions
+{
+   public static readonly JsonSerializerOptions JsonSerializerOpt = new()
+   {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+   };
+}

--- a/src/Telegraph.Sharp/Extensions/StreamExtensions.cs
+++ b/src/Telegraph.Sharp/Extensions/StreamExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Telegraph.Sharp.Extensions;
 
@@ -15,12 +15,7 @@ internal static class StreamExtensions
         where T : class
     {
         if (stream is null || !stream.CanRead) return default;
-
-        using var streamReader = new StreamReader(stream);
-        using var jsonTextReader = new JsonTextReader(streamReader);
-
-        var jsonSerializer = JsonSerializer.CreateDefault();
-        var searchResult = jsonSerializer.Deserialize<T>(jsonTextReader);
+        var searchResult = JsonSerializer.Deserialize<T>(stream,JsonSerializerExtensions.JsonSerializerOpt);
 
         return searchResult;
     }

--- a/src/Telegraph.Sharp/Requests/ApiRequestBase.cs
+++ b/src/Telegraph.Sharp/Requests/ApiRequestBase.cs
@@ -1,7 +1,8 @@
 ﻿using System.Net.Http;
 using System.Text;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Telegraph.Sharp.Extensions;
 using Telegraph.Sharp.Requests.Abstractions;
 
 namespace Telegraph.Sharp.Requests;
@@ -10,7 +11,6 @@ namespace Telegraph.Sharp.Requests;
 ///     Represents an API request.
 /// </summary>
 /// <typeparam name="TResponse">Type of result expected in result.</typeparam>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public abstract class ApiRequestBase<TResponse> : IRequest<TResponse>
 {
 
@@ -29,11 +29,11 @@ public abstract class ApiRequestBase<TResponse> : IRequest<TResponse>
     public virtual HttpContent ToHttpContent()
     {
         var content = new StringContent(
-            JsonConvert.SerializeObject(this),
+            JsonSerializer.Serialize(this,GetType(), JsonSerializerExtensions.JsonSerializerOpt),
             Encoding.UTF8,
             "application/json"
         );
-        content.Headers.ContentType!.CharSet = null;
+       content.Headers.ContentType!.CharSet = null;
         return content;
     }
 }

--- a/src/Telegraph.Sharp/Requests/CreateAccount.cs
+++ b/src/Telegraph.Sharp/Requests/CreateAccount.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+﻿using System.Net.Http;
+using System.Text.Json.Serialization;
 using Telegraph.Sharp.Types;
 
 namespace Telegraph.Sharp.Requests;
@@ -8,7 +8,6 @@ namespace Telegraph.Sharp.Requests;
 ///     Use this method to create a new Telegraph account.
 ///     On success, returns an <see cref="Account" /> object.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class CreateAccount : ApiRequestBase<Account>
 {
     /// <summary>
@@ -24,19 +23,18 @@ public class CreateAccount : ApiRequestBase<Account>
     ///     Required. Account name, helps users with several accounts remember which they are currently using.
     ///     Displayed to the user above the "Edit/Publish" button on Telegra.ph, other users don't see this name.
     /// </summary>
-    [JsonProperty(Required = Required.Always)]
-    public string ShortName { get; }
+    public string ShortName { get; init; }
 
     /// <summary>
     ///     Default author name used when creating new articles.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? AuthorName { get; set; }
 
     /// <summary>
     ///     Default profile link, opened when users click on the author's name below the title.
     ///     Can be any link, not necessarily to a Telegram profile or channel.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? AuthorUrl { get; set; }
 }

--- a/src/Telegraph.Sharp/Requests/CreatePage.cs
+++ b/src/Telegraph.Sharp/Requests/CreatePage.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json.Serialization;
 using Telegraph.Sharp.Requests.Abstractions;
 using Telegraph.Sharp.Types;
 
@@ -10,7 +9,6 @@ namespace Telegraph.Sharp.Requests;
 ///     Use this method to create a new Telegraph page.
 ///     On success, returns a <see cref="Page" /> object.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class CreatePage : ApiRequestBase<Page>, IAccessTokenTarget
 {
     /// <summary>
@@ -37,35 +35,32 @@ public class CreatePage : ApiRequestBase<Page>, IAccessTokenTarget
     /// <summary>
     ///     Required. Page title.
     /// </summary>
-    [JsonProperty(Required = Required.Always)]
-    public string Title { get; }
+    public string Title { get; init; }
 
     /// <summary>
     ///     Author name, displayed below the article's title.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? AuthorName { get; set; }
 
     /// <summary>
     ///     Profile link, opened when users click on the author's name below the title.
     ///     Can be any link, not necessarily to a Telegram profile or channel.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? AuthorUrl { get; set; }
 
     /// <summary>
     ///     Required. Content of the page.
     /// </summary>
-    [JsonProperty(Required = Required.Always)]
-    public List<Node> Content { get; }
+    public List<Node> Content { get; init; }
 
     /// <summary>
     ///     If <see langword= "true"/>, a content field will be returned in the Page object.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool ReturnContent { get; set; }
 
     /// <inheritdoc />
-    [JsonProperty(Required = Required.Always)]
-    public string AccessToken { get; }
+    public string AccessToken { get; init; }
 }

--- a/src/Telegraph.Sharp/Requests/EditAccountInfo.cs
+++ b/src/Telegraph.Sharp/Requests/EditAccountInfo.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Telegraph.Sharp.Requests.Abstractions;
 using Telegraph.Sharp.Types;
 
@@ -10,7 +9,6 @@ namespace Telegraph.Sharp.Requests;
 ///     Pass only the parameters that you want to edit.
 ///     On success, returns an <see cref="Account" /> object with the default fields.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class EditAccountInfo : ApiRequestBase<Account>, IAccessTokenTarget
 {
     /// <summary>
@@ -23,23 +21,22 @@ public class EditAccountInfo : ApiRequestBase<Account>, IAccessTokenTarget
     ///     Account name, helps users with several accounts remember which they are currently using.
     ///     Displayed to the user above the "Edit/Publish" button on Telegra.ph, other users don't see this name.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? ShortName { get; set; }
 
     /// <summary>
     ///     Default author name used when creating new articles.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? AuthorName { get; set; }
 
     /// <summary>
     ///     Profile link, opened when users click on the author's name below the title.
     ///     Can be any link, not necessarily to a Telegram profile or channel.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? AuthorUrl { get; set; }
 
     /// <inheritdoc />
-    [JsonProperty(Required = Required.Always)]
-    public string AccessToken { get; }
+    public string AccessToken { get; init; }
 }

--- a/src/Telegraph.Sharp/Requests/EditPage.cs
+++ b/src/Telegraph.Sharp/Requests/EditPage.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using Telegraph.Sharp.Types;
 
 namespace Telegraph.Sharp.Requests;
@@ -9,7 +7,6 @@ namespace Telegraph.Sharp.Requests;
 ///     Use this method to edit an existing Telegraph page.
 ///     On success, returns a <see cref="Page" /> object.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class EditPage : CreatePage
 {
     /// <summary>
@@ -26,6 +23,5 @@ public class EditPage : CreatePage
     /// <summary>
     ///     Required. Path to the page.
     /// </summary>
-    [JsonProperty(Required = Required.Always)]
-    public string Path { get; }
+    public string Path { get; init; }
 }

--- a/src/Telegraph.Sharp/Requests/GetAccountInfo.cs
+++ b/src/Telegraph.Sharp/Requests/GetAccountInfo.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json.Serialization;
 using Telegraph.Sharp.Requests.Abstractions;
 using Telegraph.Sharp.Types;
 
@@ -10,7 +9,6 @@ namespace Telegraph.Sharp.Requests;
 ///     Use this method to get information about a Telegraph account.
 ///     Returns an <see cref="Account" /> object on success.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class GetAccountInfo : ApiRequestBase<Account>, IAccessTokenTarget
 {
     /// <summary>
@@ -23,14 +21,13 @@ public class GetAccountInfo : ApiRequestBase<Account>, IAccessTokenTarget
     ///     List of account fields to return.
     ///     Available fields: "short_name", "author_name", "author_url", "auth_url","page_count".
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public List<string> Fields { get; set; } = null!;
 
     /// <summary>
     ///     Required. Access token of the Telegraph account.
     /// </summary>
-    [JsonProperty(Required = Required.Always)]
-    public string AccessToken { get; }
+    public string AccessToken { get; init; }
 
 
     /// <summary>
@@ -60,7 +57,7 @@ public class GetAccountInfo : ApiRequestBase<Account>, IAccessTokenTarget
         var list = new List<string>();
         if (!shortName && !authorName && !authorUrl && !authUrl && !pageCount)
         {
-            list.AddRange(new[] { "short_name", "author_name", "author_url" });
+            list.AddRange(["short_name", "author_name", "author_url" ]);
         }
         else
         {

--- a/src/Telegraph.Sharp/Requests/GetPage.cs
+++ b/src/Telegraph.Sharp/Requests/GetPage.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Telegraph.Sharp.Types;
 
 namespace Telegraph.Sharp.Requests;
@@ -8,7 +7,6 @@ namespace Telegraph.Sharp.Requests;
 ///     Use this method to get a Telegraph page.
 ///     Returns a <see cref="Page" /> object on success.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class GetPage : ApiRequestBase<Page>
 {
     /// <summary>
@@ -24,12 +22,11 @@ public class GetPage : ApiRequestBase<Page>
     ///     Required. Path to the Telegraph page (in the format Title-12-31, i.e. everything that comes after
     ///     http://telegra.ph/).
     /// </summary>
-    [JsonProperty(Required = Required.Always)]
-    public string Path { get; }
+    public string Path { get; init; }
 
     /// <summary>
     ///     If <see langword ="true"/>, content field will be returned in Page object.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool ReturnContent { get; set; }
 }

--- a/src/Telegraph.Sharp/Requests/GetPageList.cs
+++ b/src/Telegraph.Sharp/Requests/GetPageList.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Telegraph.Sharp.Requests.Abstractions;
 using Telegraph.Sharp.Types;
 
@@ -9,7 +8,6 @@ namespace Telegraph.Sharp.Requests;
 ///     Use this method to get a list of pages belonging to a Telegraph account.
 ///     Returns a <see cref="PageList" /> object, sorted by most recently created pages first.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class GetPageList : ApiRequestBase<PageList>, IAccessTokenTarget
 {
     /// <summary>
@@ -21,18 +19,17 @@ public class GetPageList : ApiRequestBase<PageList>, IAccessTokenTarget
     /// <summary>
     ///     Sequential number of the first page to be returned.
     /// </summary>
-    [JsonProperty("offset", DefaultValueHandling = DefaultValueHandling.Include)]
+    [JsonInclude]
     public int Offset { get; set; }
 
     /// <summary>
     ///     Limits the number of pages to be retrieved.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Include)]
+    [JsonInclude]
     public int Limit { get; set; }
 
     /// <summary>
     ///     Required. Access token of the Telegraph account.
     /// </summary>
-    [JsonProperty(Required = Required.Always)]
-    public string AccessToken { get; }
+    public string AccessToken { get; init; }
 }

--- a/src/Telegraph.Sharp/Requests/GetViews.cs
+++ b/src/Telegraph.Sharp/Requests/GetViews.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Telegraph.Sharp.Types;
 
 namespace Telegraph.Sharp.Requests;
@@ -9,7 +8,6 @@ namespace Telegraph.Sharp.Requests;
 ///     Returns a <see cref="PageViews" /> object on success.
 ///     By default, the total number of page views will be returned.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class GetViews : ApiRequestBase<PageViews>
 {
     /// <summary>
@@ -25,30 +23,29 @@ public class GetViews : ApiRequestBase<PageViews>
     ///     Required. Path to the Telegraph page (in the format Title-12-31, where 12 is the month and 31 the day the article
     ///     was first published).
     /// </summary>
-    [JsonProperty(Required = Required.Always)]
-    public string Path { get; set; }
+    public string Path { get; init; }
 
     /// <summary>
     ///     Required if month is passed. If passed, the number of page views for the requested year will be returned.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int? Year { get; set; }
 
     /// <summary>
     ///     Required if day is passed. If passed, the number of page views for the requested month will be returned.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int? Month { get; set; }
 
     /// <summary>
     ///     Required if hour is passed. If passed, the number of page views for the requested day will be returned.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int? Day { get; set; }
 
     /// <summary>
     ///     If passed, the number of page views for the requested hour will be returned.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int? Hour { get; set; }
 }

--- a/src/Telegraph.Sharp/Requests/RevokeAccessToken.cs
+++ b/src/Telegraph.Sharp/Requests/RevokeAccessToken.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-using Telegraph.Sharp.Requests.Abstractions;
+﻿using Telegraph.Sharp.Requests.Abstractions;
 using Telegraph.Sharp.Types;
 
 namespace Telegraph.Sharp.Requests;
@@ -10,7 +8,6 @@ namespace Telegraph.Sharp.Requests;
 ///     On success, returns an <see cref="Account" /> object with new <see cref="Account.AccessToken" /> and
 ///     <see cref="Account.AuthUrl" /> fields.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class RevokeAccessToken : ApiRequestBase<Account>, IAccessTokenTarget
 {
     /// <summary>
@@ -20,6 +17,5 @@ public class RevokeAccessToken : ApiRequestBase<Account>, IAccessTokenTarget
     public RevokeAccessToken(string accessToken) : base("revokeAccessToken") => AccessToken = accessToken;
 
     /// <inheritdoc />
-    [JsonProperty(Required = Required.Always)]
-    public string AccessToken { get; }
+    public string AccessToken { get; init; }
 }

--- a/src/Telegraph.Sharp/Telegraph.Sharp.csproj
+++ b/src/Telegraph.Sharp/Telegraph.Sharp.csproj
@@ -11,7 +11,7 @@
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <PackageVersion>1.0.0</PackageVersion>
+        <PackageVersion>2.0.0</PackageVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Title>Telegraph.Sharp</Title>
         <Description>

--- a/src/Telegraph.Sharp/Telegraph.Sharp.csproj
+++ b/src/Telegraph.Sharp/Telegraph.Sharp.csproj
@@ -3,8 +3,8 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <RootNamespace>Telegraph.Sharp</RootNamespace>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-        <LangVersion>11</LangVersion>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>12</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup Label="Package">
@@ -29,10 +29,6 @@
             $(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb
         </AllowedOutputExtensionsInPackageBuildOutputFolder>
     </PropertyGroup>
-    
-    <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-    </ItemGroup>
 
     <ItemGroup>
         <None Include="../../package-icon.png">

--- a/src/Telegraph.Sharp/TelegraphClient.cs
+++ b/src/Telegraph.Sharp/TelegraphClient.cs
@@ -100,8 +100,7 @@ public async Task<TResponse> MakeRequestAsync<TResponse>(
     Func<HttpResponseMessage, Task<TResponse>> deserializeFunc,
     CancellationToken cancellationToken = default)
 {
-    if (request is null)
-        throw new ArgumentNullException(nameof(request));
+    ArgumentNullException.ThrowIfNull(request);
 
     using var httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
     httpRequest.Content = request.ToHttpContent();

--- a/src/Telegraph.Sharp/TelegraphClientExtension.ApiMethods.cs
+++ b/src/Telegraph.Sharp/TelegraphClientExtension.ApiMethods.cs
@@ -135,7 +135,7 @@ public static partial class TelegraphClientExtension
         await telegraphClient.MakeApiRequestAsync(
             new GetPage(path)
             {
-                ReturnContent = returnContent
+                ReturnContent = returnContent,
             }, cancellationToken
         ).ConfigureAwait(false);
 

--- a/src/Telegraph.Sharp/Types/Account.cs
+++ b/src/Telegraph.Sharp/Types/Account.cs
@@ -1,50 +1,40 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-
-namespace Telegraph.Sharp.Types;
+﻿namespace Telegraph.Sharp.Types;
 
 /// <summary>
 ///     This object represents a Telegraph account.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class Account
 {
     /// <summary>
     ///     Account name, helps users with several accounts remember which they are currently using.
     ///     Displayed to the user above the "Edit/Publish" button on Telegra.ph, other users don't see this name.
     /// </summary>
-    [JsonProperty]
     public string? ShortName { get; set; }
 
     /// <summary>
     ///     Default author name used when creating new articles.
     /// </summary>
-    [JsonProperty]
     public string? AuthorName { get; set; }
 
     /// <summary>
     ///     Profile link, opened when users click on the author's name below the title. Can be any link, not necessarily to a
     ///     Telegram profile or channel.
     /// </summary>
-    [JsonProperty]
     public string? AuthorUrl { get; set; }
 
     /// <summary>
     ///     Access token of the Telegraph account.
     /// </summary>
-    [JsonProperty]
     public string? AccessToken { get; set; }
 
     /// <summary>
     ///     URL to authorize a browser on telegra.ph and connect it to a Telegraph account. This URL is valid for
     ///     only one use and for 5 minutes only.
     /// </summary>
-    [JsonProperty]
     public string? AuthUrl { get; set; }
 
     /// <summary>
     ///    Number of pages belonging to the Telegraph account.
     /// </summary>
-    [JsonProperty]
     public int? PageCount { get; set; }
 }

--- a/src/Telegraph.Sharp/Types/Node.cs
+++ b/src/Telegraph.Sharp/Types/Node.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using Telegraph.Sharp.Converters;
 
 namespace Telegraph.Sharp.Types;
@@ -22,7 +22,8 @@ public partial class Node
     ///     Name of the DOM element. Available tags: a, aside, b, blockquote, br, code, em, figcaption, figure, h3, h4, hr, i,
     ///     iframe, img, li, ol, p, pre, s, strong, u, ul, video.
     /// </summary>
-    [JsonProperty("tag", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("tag")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string TagValue
     {
         get => Tag.ToString().ToLower();
@@ -48,13 +49,14 @@ public partial class Node
     ///     Optional. Attributes of the DOM element. Key of object represents name of attribute, value represents value of
     ///     attribute. Available attributes: href, src.
     /// </summary>
-    [JsonProperty("attrs", DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonPropertyName("attrs")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public TagAttributes? Attributes { get; set; }
 
     /// <summary>
     ///     Optional. List of child nodes for the DOM element.
     /// </summary>
-    [JsonProperty("children", DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public List<Node>? Children { get; set; }
 
     #region Constructors

--- a/src/Telegraph.Sharp/Types/Page.cs
+++ b/src/Telegraph.Sharp/Types/Page.cs
@@ -1,73 +1,66 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Telegraph.Sharp.Types;
 
 /// <summary>
 ///     This object represents a page on Telegraph.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class Page
 {
     /// <summary>
     ///     Path to the page.
     /// </summary>
-    [JsonProperty]
     public string Path { get; set; } = null!;
 
     /// <summary>
     ///     URL of the page.
     /// </summary>
-    [JsonProperty]
     public string Url { get; set; } = null!;
 
     /// <summary>
     ///     Title of the page.
     /// </summary>
-    [JsonProperty]
     public string Title { get; set; } = null!;
 
     /// <summary>
     ///     Description of the page.
     /// </summary>
-    [JsonProperty]
     public string Description { get; set; } = null!;
 
     /// <summary>
     ///     Name of the author, displayed below the title.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? AuthorName { get; set; }
 
     /// <summary>
     ///     Profile link, opened when users click on the author's name below the title.
     ///     Can be any link, not necessarily to a Telegram profile or channel.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? AuthorUrl { get; set; }
 
     /// <summary>
     ///     Image URL of the page.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? ImageUrl { get; set; }
 
     /// <summary>
     ///     Content of the page.
     /// </summary>
-    [JsonProperty("content", DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public List<Node>? Content { get; set; }
 
     /// <summary>
     ///     Number of page views for the page.
     /// </summary>
-    [JsonProperty]
     public int Views { get; set; }
 
     /// <summary>
     ///     Only returned if access token passed. True, if the target Telegraph account can edit the page.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool? CanEdit { get; set; }
 }

--- a/src/Telegraph.Sharp/Types/PageList.cs
+++ b/src/Telegraph.Sharp/Types/PageList.cs
@@ -1,34 +1,23 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Telegraph.Sharp.Types;
 
 /// <summary>
 ///     This object represents a list of Telegraph articles belonging to an account. Most recently created articles first.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
-public class PageList : IEnumerable<Page>
+public class PageList
 {
     /// <summary>
     ///     Total number of pages belonging to the target Telegraph account.
     /// </summary>
-    [JsonProperty]
     public int TotalCount { get; set; }
 
     /// <summary>
     ///     Requested pages of the target Telegraph account.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public List<Page> Pages { get; set; } = null!;
 
-    #region IEnumarable implementation
-
-    /// <inheritdoc />
-    public IEnumerator<Page> GetEnumerator() => Pages.GetEnumerator();
-
-    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-    #endregion
 }

--- a/src/Telegraph.Sharp/Types/PageViews.cs
+++ b/src/Telegraph.Sharp/Types/PageViews.cs
@@ -1,17 +1,12 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-
-namespace Telegraph.Sharp.Types;
+﻿namespace Telegraph.Sharp.Types;
 
 /// <summary>
 ///     This object represents the number of page views for a Telegraph article.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class PageViews
 {
     /// <summary>
     ///     Number of page views for the target page.
     /// </summary>
-    [JsonProperty]
     public int Views { get; set; }
 }

--- a/src/Telegraph.Sharp/Types/TagAttributes.cs
+++ b/src/Telegraph.Sharp/Types/TagAttributes.cs
@@ -1,31 +1,29 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace Telegraph.Sharp.Types;
 
 /// <summary>
 ///     Attributes of the DOM element. Key of object represents name of attribute, value represents value of attribute.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class TagAttributes
 {
-    private string? _src;
+    private readonly string? _src;
 
     
     /// <summary>
     /// Link value.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-    public string? Href { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public string? Href { get; init; }
 
     /// <summary>
     /// Source value.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? Src
     {
         get => _src;
-        set => _src = value is null ? null :
-            value.StartsWith(Constants.Telegpaph) ? value.Substring(Constants.Telegpaph.Length) : value;
+        init => _src = value is null ? null :
+            value.StartsWith(Constants.Telegpaph) ? value[Constants.Telegpaph.Length..] : value;
     }
 }

--- a/src/Telegraph.Sharp/Types/TelegraphApiResponse.cs
+++ b/src/Telegraph.Sharp/Types/TelegraphApiResponse.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace Telegraph.Sharp.Types;
 
@@ -7,24 +6,22 @@ namespace Telegraph.Sharp.Types;
 /// Represents a API response result.
 /// </summary>
 /// <typeparam name="T">Expected type of operation result.</typeparam>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class TelegraphApiResponse<T>
 {
     /// <summary>
     /// Gets a value indicating whether the request was successful.
     /// </summary>
-    [JsonProperty] 
     public bool Ok { get; set; }
 
     /// <summary>
     /// Gets the result object.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public T? Result { get; set; }
 
     /// <summary>
     /// Contains information about why a request was unsuccessful.
     /// </summary>
-    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? Error { get; set; }
 }

--- a/src/Telegraph.Sharp/Types/TelegraphFile.cs
+++ b/src/Telegraph.Sharp/Types/TelegraphFile.cs
@@ -1,12 +1,10 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace Telegraph.Sharp.Types;
 
 /// <summary>
 /// This object represents the file uploaded to Telegraph.
 /// </summary>
-[JsonObject(MemberSerialization.OptIn, NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
 public class TelegraphFile
 {
     /// <summary>
@@ -22,7 +20,6 @@ public class TelegraphFile
     /// <summary>
     /// Soucre value.
     /// </summary>
-    [JsonProperty]
     public string Src { get; }
 
 

--- a/tests/Telegraph.Sharp.Tests.Integ/Data/FileTestCase.cs
+++ b/tests/Telegraph.Sharp.Tests.Integ/Data/FileTestCase.cs
@@ -1,4 +1,5 @@
 ﻿using Telegraph.Sharp.Types;
+using Xunit;
 
 namespace Telegraph.Sharp.Tests.Integ.Data;
 
@@ -32,7 +33,7 @@ public record FileTestCase
 
     public static FileTestCase Mp4MaxSize => new FileTestCase("test10MB.mp4", FileTypeEnum.MP4);
     
-    public static readonly IEnumerable<object[]> TestCasesData = TestCases.Select(x => new object[] {x});
+    public static readonly TheoryData<FileTestCase> TestCasesData = new(TestCases);
 
     public override string ToString() => FileToUpload.FileType.ToString();
 }

--- a/tests/Telegraph.Sharp.Tests.Integ/Telegraph.Sharp.Tests.Integ.csproj
+++ b/tests/Telegraph.Sharp.Tests.Integ/Telegraph.Sharp.Tests.Integ.csproj
@@ -3,9 +3,9 @@
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <LangVersion>11</LangVersion>
+        <LangVersion>12</LangVersion>
         <IsPackable>false</IsPackable>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/Telegraph.Sharp.Tests.Unit/Data/SerialOpt.cs
+++ b/tests/Telegraph.Sharp.Tests.Unit/Data/SerialOpt.cs
@@ -1,0 +1,11 @@
+using System.Text.Json;
+
+namespace Telegraph.Sharp.Tests.Unit.Data;
+
+public static class SerialOpt
+{
+    public static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+    };
+}

--- a/tests/Telegraph.Sharp.Tests.Unit/Serialization/NodeTests.cs
+++ b/tests/Telegraph.Sharp.Tests.Unit/Serialization/NodeTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json;
+using Telegraph.Sharp.Tests.Unit.Data;
 using Telegraph.Sharp.Types;
 using Xunit;
 
@@ -17,7 +18,7 @@ public class NodeTests
             Node.ImageFigure("https://telegra.ph/images/logo.png", "Logo")
         };
 
-        var json = JsonConvert.SerializeObject(nodes);
+        var json = JsonSerializer.Serialize(nodes,SerialOpt.SerializerOptions);
         Assert.Contains("\"tag\":\"figcaption\"", json);
     }
 
@@ -61,7 +62,7 @@ public class NodeTests
                                  }
                              ]
                              """;
-        var nodes = JsonConvert.DeserializeObject<List<Node>>(value);
+        var nodes = JsonSerializer.Deserialize<List<Node>>(value,SerialOpt.SerializerOptions);
         Assert.NotNull(nodes);
         Assert.Equal(3, nodes.Count);
         Assert.Equal("Test header", nodes[0].Children![0].Value);

--- a/tests/Telegraph.Sharp.Tests.Unit/Serialization/RequestsTests.cs
+++ b/tests/Telegraph.Sharp.Tests.Unit/Serialization/RequestsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Telegraph.Sharp.Requests;
+using Telegraph.Sharp.Tests.Unit.Data;
 using Telegraph.Sharp.Types;
 using Xunit;
 
@@ -16,7 +17,7 @@ public class RequestsTests
             AuthorName = "test1",
             AuthorUrl = "test2"
         };
-        var json = JsonConvert.SerializeObject(request);
+        var json = JsonSerializer.Serialize(request,SerialOpt.SerializerOptions);
         Assert.Contains("\"author_url\":\"test2\"", json);
     }
 
@@ -25,10 +26,11 @@ public class RequestsTests
     {
         var request = new CreatePage("test", "Title", new List<Node>())
         {
+            
             AuthorName = "test1",
             AuthorUrl = "test2"
         };
-        var json = JsonConvert.SerializeObject(request);
+        var json = JsonSerializer.Serialize(request,SerialOpt.SerializerOptions);
         Assert.Contains("\"author_url\":\"test2\"", json);
     }
 }

--- a/tests/Telegraph.Sharp.Tests.Unit/Telegraph.Sharp.Tests.Unit.csproj
+++ b/tests/Telegraph.Sharp.Tests.Unit/Telegraph.Sharp.Tests.Unit.csproj
@@ -4,8 +4,8 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <ImplicitUsings>disable</ImplicitUsings>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>11</LangVersion>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>12</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Upgrading to the latest LTS version of dotnet is necessary. Replacing Newtonsoft.Json with System.Text.Json may help improve performance. For other versions of dotnet it is still possible to use version 1.0.0.